### PR TITLE
Potential fix of the truncated parabola

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,10 @@
+# v0.2.3 (03/April/2025)
+* Fixed bug in the truncated parabola, used for chromatic components of the CSF
+* Added an example showing how to use broadcasting
+
+# v0.2.2 (11/January/2025)
+* All paramers are now broadcasted - see README.md for more details.
+
 # v0.2.1 (29/July/2024)
 * Added more example files (`plot_csf_internal_mechanisms.m` and `plot_temporal_csf.m`) for castleCSF applications.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ Currently, the code is provided as a Matlab class in the directory `matlab`.
 
 Please check the directory `examples` to use castleCSF for predicting and plotting contrast sensitivity.
 
+# Broadcasting across multiple dimensions
+
+castleCSF fully support broadcasting. For example, to predict sensitivity for all combinations of spatial and temporal frequencies, you can call:
+```
+csf_model = CSF_castleCSF();
+
+t_frequency = logspace( 0.1, log10(64), 30 );           % Temporal frequency in Hz
+s_frequency = logspace( log10(0.5), log10(64), 30 );    % Spatial frequency in cycles per degree
+
+csf_pars = struct( 's_frequency', s_frequency, 't_frequency', t_frequency', 'area', 1, 'luminance', 100 );
+S = csf_model.sensitivity( csf_pars );        
+```
+Note that `s_frequency` is passed as a [1 30] tensor and `t_frequency` as a [30 1] tensor (see transpose). The resulting sensitivity tensor `S` is [30 30].
+
+To compute sensitivity for large number of data points, use broadcasting instead of calling `csf_model.sensitivity` multiple times. 
+See also [examples/plot_spatiotemporal_csf.m](examples/plot_spatiotemporal_csf.m).
+
+
 ## Data
 
 Each datapoint represents a Gabor patch at the detection threshold, either for individual observers, or averaged across all observers. The sensitivity is averaged in the log-contrast space. 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please check the directory `examples` to use castleCSF for predicting and plotti
 
 ### Broadcasting across multiple dimensions
 
-castleCSF fully support broadcasting. For example, to predict sensitivity for all combinations of spatial and temporal frequencies, you can call:
+castleCSF fully support broadcasting. For example, to predict sensitivity for all combinations of spatial and temporal frequencies, you can run:
 ```
 csf_model = CSF_castleCSF();
 
@@ -32,7 +32,7 @@ s_frequency = logspace( log10(0.5), log10(64), 30 );    % Spatial frequency in c
 csf_pars = struct( 's_frequency', s_frequency, 't_frequency', t_frequency', 'area', 1, 'luminance', 100 );
 S = csf_model.sensitivity( csf_pars );        
 ```
-Note that `s_frequency` is passed as a [1 30] tensor and `t_frequency` as a [30 1] tensor (see transpose). The resulting sensitivity tensor `S` is [30 30].
+Note that `s_frequency` is passed as a [1 30] tensor and `t_frequency` as a [30 1] tensor (see the transpose). The resulting sensitivity tensor `S` has the size of [30 30].
 
 To compute sensitivity for large number of data points, use broadcasting instead of calling `csf_model.sensitivity` multiple times. 
 See also [matlab/examples/plot_spatiotemporal_csf.m](matlab/examples/plot_spatiotemporal_csf.m).

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ The details about the model and the dataset can be found on the project [website
 
 Currently, the code is provided as a Matlab class in the directory `matlab`. 
 
-### Example
+### Examples
 
 Please check the directory `examples` to use castleCSF for predicting and plotting contrast sensitivity.
 
-# Broadcasting across multiple dimensions
+### Broadcasting across multiple dimensions
 
 castleCSF fully support broadcasting. For example, to predict sensitivity for all combinations of spatial and temporal frequencies, you can call:
 ```
@@ -35,7 +35,7 @@ S = csf_model.sensitivity( csf_pars );
 Note that `s_frequency` is passed as a [1 30] tensor and `t_frequency` as a [30 1] tensor (see transpose). The resulting sensitivity tensor `S` is [30 30].
 
 To compute sensitivity for large number of data points, use broadcasting instead of calling `csf_model.sensitivity` multiple times. 
-See also [examples/plot_spatiotemporal_csf.m](examples/plot_spatiotemporal_csf.m).
+See also [matlab/examples/plot_spatiotemporal_csf.m](matlab/examples/plot_spatiotemporal_csf.m).
 
 
 ## Data
@@ -106,10 +106,20 @@ Columns:
 
 
 # Release Notes
+
+* v0.2.3 (03/April/2025)
+  - Fixed bug in the truncated parabola, used for chromatic components of the CSF
+  - Added an example showing how to use broadcasting
+
+* v0.2.2 (11/January/2025)
+  - All paramers are now broadcasted - see README.md for more details.
+
+* v0.2.1 (29/July/2024)
+  - Added more example files (`plot_csf_internal_mechanisms.m` and `plot_temporal_csf.m`) for castleCSF applications.
+
 * v0.2.0 (27/March/2024) 
   - Version used in Ashraf et al. (2024), ([castleCSF](http://dx.doi.org/10.1167/jov.24.4.5)).
 
-* v0.1.0 - Initial internal release (21/Dec/2023).
-  
+* v0.1.0 - Initial internal release (21/Dec/2023).  
 
 The detailed list of changes can be found in [ChangeLog.md](ChangeLog.md).

--- a/matlab/CSF_castleCSF_chrom.m
+++ b/matlab/CSF_castleCSF_chrom.m
@@ -133,14 +133,10 @@ classdef CSF_castleCSF_chrom < CSF_base
             bw = ch_pars.bw;
 
             % Truncated log-parabola for chromatic directions
-            S_LP = 10.^( -abs(log10(freq) - log10(f_max)).^2./(2.^bw) );
+            S_LP = 10.^( -abs(log10(freq) - log10(f_max)).^2./(2^bw) );
             ss = (freq<f_max);
-            max_mat = repmat(max(S_LP), size(freq));
-            if numel(max_mat) == 1
-                S_LP(ss) = max_mat;
-            else
-                S_LP(ss) = max_mat(ss);
-            end
+            max_S_LP = 1;
+            S_LP(ss) = max_S_LP;
 
             S_peak = S_max .* S_LP;
 


### PR DESCRIPTION
The current code finds the maximum relative sensitivity (`S_LP`) across the sampled frequencies. But if we pass only low-frequency as a parameter and no frequencies close to `f_max`, the truncation will not happen. 

The maximum of S_LP is always 1 (when freq==f_max) so we can just replace the values with 1 to truncate the parabola. 




